### PR TITLE
Use 9fans repo for package acme.

### DIFF
--- a/fmt.go
+++ b/fmt.go
@@ -17,7 +17,7 @@ import (
 	"os/exec"
 	"strconv"
 
-	"code.google.com/p/goplan9/plan9/acme"
+	"9fans.net/go/acme"
 )
 
 type bodyReader struct{ *acme.Win }


### PR DESCRIPTION
We should use the new 9fans.net/go/acme repo for package acme.
